### PR TITLE
Adding command to initialize database tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 env/
 falcon_multiqc.egg-info
 __pycache__
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 env/
 falcon_multiqc.egg-info
 __pycache__
-.vscode/settings.json
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "env/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.pythonPath": "C:\\Users\\New\\AppData\\Local\\Programs\\Python\\Python38-32\\python.exe"
+    "python.pythonPath": "env/bin/python"
 }

--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,1 @@
+Currently only includes model skeletons.

--- a/database/README.md
+++ b/database/README.md
@@ -1,1 +1,3 @@
-Currently only includes model skeletons.
+To use the database, firstly modify config.py DATABASE_URI to point to your database server.
+
+See [this guide's section 'Setting up a Postgres server locally'](https://www.learndatasci.com/tutorials/using-databases-python-postgres-sqlalchemy-and-alembic/#SettingupaPostgresserverlocally). When setting this up, keep note of the database password and port.

--- a/database/config.py
+++ b/database/config.py
@@ -1,11 +1,7 @@
 ### config.py ###
 
-# For now, to test depolyment of this database locally, you will have to download the megaqc_db repo, 
-# and set the URI below to log into your own database server of choice 
+# For now, to test the database locally, you will have to set the URI below to log into your own database server of choice.
+# TODO Uncomment the below with your own server's information.
+# Scheme: "postgres+psycopg2://<USERNAME>:<PASSWORD>@<IP_ADDRESS>:<PORT>/<DATABASE_NAME>"
 
-# DATABASE_URI: "postgres+psycopg2://<USERNAME>:<PASSWORD>@<IP_ADDRESS>:<PORT>/<DATABASE_NAME>"
-
-
-#examples: 
-# DATABASE_URI = postgresql+psycopg2://scott:abc123@localhost/mydatabase
-# DATABASE_URI = mysql+mysqldb://scott:tiger@localhost/foo
+# DATABASE_URI = "postgres+psycopg2://<USERNAME>:<PASSWORD>@<IP_ADDRESS>:<PORT>/<DATABASE_NAME>"

--- a/database/crud.py
+++ b/database/crud.py
@@ -1,21 +1,35 @@
 from sqlalchemy import create_engine, MetaData
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
-from config import *
+from contextlib import contextmanager
+from .config import DATABASE_URI
+from .models import Base
 
-### Base object maintains a catalog of classes/tables mapped to the database
-### Also replaces all Column objects with python descriptors
-Base = declarative_base()
+engine = create_engine(DATABASE_URI, echo=True)
 
-
-
-engine = create_engine(DATABASE_URI, echo = True)
+# Global Session object factory.
+# Create new sessions using Session(), which is done for you in session_scope() below.
 Session = sessionmaker(bind=engine)
-session = Session()
-Base.metadata.create_all(engine)
-# recreate database
+
+# Import session_scope to use the database.
+# Doing so will run the above engine binding and create the global Session.
+# Use it by "with session_scope() as session:"
+@contextmanager
+def session_scope():
+    session = Session()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+# Creates the database tables. Usually only done once.
+def create_database():
+    Base.metadata.create_all(engine)
+
+# Recreate database will destroy the database and re-build it with empty tables (use only for development).
 def recreate_database():
     Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
-
-

--- a/database/read_me
+++ b/database/read_me
@@ -1,1 +1,0 @@
-Current only includes model skeletons

--- a/falcon_multiqc/commands/initialize_database.py
+++ b/falcon_multiqc/commands/initialize_database.py
@@ -1,0 +1,10 @@
+import click
+from database.crud import create_database
+
+# Command for initalizing database.
+
+
+@click.command()
+def cli():
+    """Creates a new database"""
+    create_database()

--- a/requirements.system
+++ b/requirements.system
@@ -1,0 +1,2 @@
+libpq-dev
+python-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 click==7.1.2
+sqlalchemy
+psycopg2


### PR DESCRIPTION
## PR Description

- Firstly **updated our requirements.txt** (this is used when installing our tool with `pip install --editable .` so it knows what dependent python packages to install). I see to run our current code we need sqlalchemy and psycopg2. In future, if you ever need to pip install something for new code you're adding, add it to `requirements.txt`.

  - Also added 'requirements.system' with system requirements required (i.e. things that already need to be installed on the machine before running our python program). The two I have are required for psycopg2. 

- Rearranged some of the global variables to make more sense (e.g. Base now in models.py). 

- Fixed some imports

- **Added command 'initalize_database'** which currently creates the database/tables in the given server.



## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [x] `README.md` is updated

