### PR TITLE
Add connect command

### DIFF
--- a/database/config.py
+++ b/database/config.py
@@ -1,2 +1,3 @@
 ### config.py ###
 
+DATABASE_URI = "postgres+psycopg2://USERNAME:PASSWORD@IP_ADDRESS:0/DATABASE_NAME"

--- a/database/config.py
+++ b/database/config.py
@@ -1,8 +1,2 @@
 ### config.py ###
 
-# For now, to test the database locally, you will have to set the URI below to log into your own database server of choice.
-# TODO Uncomment the below with your own server's information.
-# Scheme: "postgres+psycopg2://<USERNAME>:<PASSWORD>@<IP_ADDRESS>:<PORT>/<DATABASE_NAME>"
-
-# DATABASE_URI = "postgres+psycopg2://<USERNAME>:<PASSWORD>@<IP_ADDRESS>:<PORT>/<DATABASE_NAME>"
-DATABASE_URI = "postgres+psycopg2://postgres:bentopostgres@localhost:5432/megaqc1"

--- a/database/models.py
+++ b/database/models.py
@@ -115,3 +115,13 @@ class Cohort(Base):
     def __repr__(self):
         return "<Cohort(id='{}'，disease='{}，size='{}''>" \
             .format(self.id, self.disease, self.size)
+
+tables = []
+def tables_check():
+    for name, model_class in Base._decl_class_registry.items():
+        try:
+            tables.append(model_class.__tablename__)
+        except:
+            # Sometimes there is an object that's not a model class in this iteration.
+            continue
+    return tables

--- a/database/models.py
+++ b/database/models.py
@@ -116,8 +116,8 @@ class Cohort(Base):
         return "<Cohort(id='{}'，disease='{}，size='{}''>" \
             .format(self.id, self.disease, self.size)
 
-tables = []
-def tables_check():
+def get_tables():
+    tables = []
     for name, model_class in Base._decl_class_registry.items():
         try:
             tables.append(model_class.__tablename__)

--- a/falcon_multiqc/commands/connect.py
+++ b/falcon_multiqc/commands/connect.py
@@ -1,11 +1,13 @@
 import click
 from getpass import getpass
-from sqlalchemy import create_engine
-from sqlalchemy.engine.url import make_url
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import OperationalError
 
 # connect command allows user to modify the config.py DATABASE_URI with their username, password and database name
 # if the user has not yet made a falcon_multiqc database, this command allows them to make a new one
+
+#global list 
+falcon_multiqc_schema = ['cohort', 'patient', 'batch', 'sample', 'PatientBatch', 'raw_data']
 
 # function to modify the config.py file with a new DATABASE_URI for the current user
 def create_config(username, password, server_address, database):
@@ -17,7 +19,7 @@ def create_config(username, password, server_address, database):
             config_file.write(f'DATABASE_URI = "postgres+psycopg2://{username}:{password}@localhost:5432/{database}"')
 
 @click.command()
-@click.option("-a", "--server_address", type=click.STRING, required=False, help="Enter IPV4 and port for postgres server")
+@click.option("-a", "--server_address", type=click.STRING, required=False, help="Enter IPV4 and port for postgres server (e.g. 192.0.2.1 5432")
 def cli(server_address):
     """Connects the user to a postgres database, creates new database one doesn't exist"""
 
@@ -31,24 +33,37 @@ def cli(server_address):
                 login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}')
             else:
                 login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432')
+            login_engine.connect().close() # try to form a connection with db using username/password and immediately close - raises OperationaError if wrong   
             break
-        except OperationalError:
+        except OperationalError: 
             click.echo("Username or password could not connect to postgres server\n")
     with login_engine.connect() as conn:
-        databases = list(conn.execute("SELECT datname FROM pg_database WHERE datistemplate = false;")) # queries postgreSQL for list of avaliable databases
+        databases = list(conn.execute("SELECT datname FROM pg_database WHERE datistemplate = false;")) # queries postgreSQL for list of avaliable databases #.scalar() is None
         click.echo(f'\nAvaliable databases under {username} user are:')
         [click.echo(f'{d[0]}') for d in databases]
 
-        database = click.prompt("Enter database name to connect, or enter new name to create a new falcon_multiqc database")
-        if (database,) in databases:
-            create_config(username, password, server_address, database) # re-create config file with proper connection URL 
-        else:
-            """Creates a new database"""
-            create_config(username, password, server_address, database) 
-            conn.execute("commit") # databases cannot be created inside transactions, this line will close the previous transaction 
-            conn.execute(f"create database {database}") # create an empty database 
-            from database.crud import create_database
-            create_database() # populate the database with tables 
-            click.echo("Database has been created!")
+        while True:
+            database = click.prompt("Enter database name to connect, or enter new name to create a new falcon_multiqc database")
+            if (database,) in databases:
+                create_config(username, password, server_address, database) # re-create config file with proper connection URL 
+                if server_address:
+                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{(database,)[0]}')
+                else:
+                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432/{(database,)[0]}')
+                inspector = inspect(check_db_engine)
+                if not falcon_multiqc_schema == inspector.get_table_names():
+                    click.echo("\n===\nWarning, selected database is not a falcon_multiqc database, please try again or create a new database\n===\n")
+                    continue
+                check_db_engine.dispose()
+            else:
+                """Creates a new database"""
+                click.echo("Creating new database...")
+                create_config(username, password, server_address, database) 
+                conn.execute("commit") # databases cannot be created inside transactions, this line will close the previous transaction 
+                conn.execute(f"create database {database}") # create an empty database 
+                from database.crud import create_database
+                create_database() # populate the database with tables 
+                click.echo("Database has been created!")
+            break
         click.echo(f"You are now connected to database {database}!")
     login_engine.dispose()

--- a/falcon_multiqc/commands/connect.py
+++ b/falcon_multiqc/commands/connect.py
@@ -1,0 +1,54 @@
+import click
+from getpass import getpass
+from sqlalchemy import create_engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.exc import OperationalError
+
+# connect command allows user to modify the config.py DATABASE_URI with their username, password and database name
+# if the user has not yet made a falcon_multiqc database, this command allows them to make a new one
+
+# function to modify the config.py file with a new DATABASE_URI for the current user
+def create_config(username, password, server_address, database):
+    with open("database/config.py", 'w') as config_file:
+        config_file.write("### config.py ###\n\n")
+        if server_address:
+            config_file.write(f'DATABASE_URI = "postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{database}"')
+        else:
+            config_file.write(f'DATABASE_URI = "postgres+psycopg2://{username}:{password}@localhost:5432/{database}"')
+
+@click.command()
+@click.option("-a", "--server_address", type=click.STRING, required=False, help="Enter IPV4 and port for postgres server")
+def cli(server_address):
+    """Connects the user to a postgres database, creates new database one doesn't exist"""
+
+    click.echo("Please enter the username and password for your postgres server\n")
+    while True:
+        username = click.prompt("Enter username (e.g. postgres)")
+        password = getpass("Enter password: ")
+        try:
+            if server_address:
+                server_address = server_address.split()
+                login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}')
+            else:
+                login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432')
+            break
+        except OperationalError:
+            click.echo("Username or password could not connect to postgres server\n")
+    with login_engine.connect() as conn:
+        databases = list(conn.execute("SELECT datname FROM pg_database WHERE datistemplate = false;")) # queries postgreSQL for list of avaliable databases
+        click.echo(f'\nAvaliable databases under {username} user are:')
+        [click.echo(f'{d[0]}') for d in databases]
+
+        database = click.prompt("Enter database name to connect, or enter new name to create a new falcon_multiqc database")
+        if (database,) in databases:
+            create_config(username, password, server_address, database) # re-create config file with proper connection URL 
+        else:
+            """Creates a new database"""
+            create_config(username, password, server_address, database) 
+            conn.execute("commit") # databases cannot be created inside transactions, this line will close the previous transaction 
+            conn.execute(f"create database {database}") # create an empty database 
+            from database.crud import create_database
+            create_database() # populate the database with tables 
+            click.echo("Database has been created!")
+        click.echo(f"You are now connected to database {database}!")
+    login_engine.dispose()

--- a/falcon_multiqc/commands/connect.py
+++ b/falcon_multiqc/commands/connect.py
@@ -47,9 +47,9 @@ def cli(server_address):
             if (database,) in databases:
                 create_config(username, password, server_address, database) # re-create config file with proper connection URL 
                 if server_address:
-                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{(database,)[0]}')
+                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{database}')
                 else:
-                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432/{(database,)[0]}')
+                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432/{database}')
                 inspector = inspect(check_db_engine)
                 if not falcon_multiqc_schema == inspector.get_table_names():
                     click.echo("\n===\nWarning, selected database is not a falcon_multiqc database, please try again or create a new database\n===\n")

--- a/falcon_multiqc/commands/connect.py
+++ b/falcon_multiqc/commands/connect.py
@@ -1,69 +1,79 @@
 import click
+import re
+import sys
 from getpass import getpass
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import OperationalError
+from database.models import tables_check
 
 # connect command allows user to modify the config.py DATABASE_URI with their username, password and database name
 # if the user has not yet made a falcon_multiqc database, this command allows them to make a new one
 
-#global list 
-falcon_multiqc_schema = ['cohort', 'patient', 'batch', 'sample', 'PatientBatch', 'raw_data']
-
 # function to modify the config.py file with a new DATABASE_URI for the current user
-def create_config(username, password, server_address, database):
+def create_config(username, password, uri, database):
     with open("database/config.py", 'w') as config_file:
         config_file.write("### config.py ###\n\n")
-        if server_address:
-            config_file.write(f'DATABASE_URI = "postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{database}"')
+        if uri:
+            config_file.write(f'DATABASE_URI = "postgres+psycopg2://{uri[0]}:{uri[1]}@{uri[2]}:{uri[3]}/{uri[4]}"')
         else:
             config_file.write(f'DATABASE_URI = "postgres+psycopg2://{username}:{password}@localhost:5432/{database}"')
 
 @click.command()
-@click.option("-a", "--server_address", type=click.STRING, required=False, help="Enter IPV4 and port for postgres server (e.g. 192.0.2.1 5432")
-def cli(server_address):
+@click.option("-u", "--uri", type=click.STRING, required=False, help="Enter complete DATABASE_URI (e.g. 'postgres+psycopg2://USERNAME:PASSWORD@IP_ADDRESS:PORT/DATABASE_NAME') - Note, this can create a new db as well")
+def cli(uri):
     """Connects the user to a postgres database, creates new database one doesn't exist"""
 
-    click.echo("Please enter the username and password for your postgres server\n")
+    username, password, database = (None, None, None)
     while True:
-        username = click.prompt("Enter username (e.g. postgres)")
-        password = getpass("Enter password: ")
+        if not uri:
+            click.echo("Please enter the username and password for your postgres server:")
+            username = click.prompt("Enter username (e.g. postgres)")
+            password = getpass("Enter password: ")
         try:
-            if server_address:
-                server_address = server_address.split()
-                login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}')
+            if uri:
+                uri = re.split(':|@|/', uri)[-5:]
+                login_engine = create_engine(f'postgres+psycopg2://{uri[0]}:{uri[1]}@{uri[2]}:{uri[3]}')
             else:
                 login_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432')
             login_engine.connect().close() # try to form a connection with db using username/password and immediately close - raises OperationaError if wrong   
             break
         except OperationalError: 
+            if uri:
+                click.echo("Error: username or password could not connect to postgres server\nExiting falcon_multiqc...")
+                sys.exit(1)
             click.echo("Username or password could not connect to postgres server\n")
     with login_engine.connect() as conn:
         databases = list(conn.execute("SELECT datname FROM pg_database WHERE datistemplate = false;")) # queries postgreSQL for list of avaliable databases #.scalar() is None
-        click.echo(f'\nAvaliable databases under {username} user are:')
-        [click.echo(f'{d[0]}') for d in databases]
 
         while True:
-            database = click.prompt("Enter database name to connect, or enter new name to create a new falcon_multiqc database")
-            if (database,) in databases:
-                create_config(username, password, server_address, database) # re-create config file with proper connection URL 
-                if server_address:
-                    check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@{server_address[0]}:{server_address[1]}/{database}')
+            if not uri:
+                click.echo(f'\nAvaliable databases under {username} user are:')
+                [click.echo(f'{d[0]}') for d in databases]
+                database = click.prompt("\nEnter database name to connect, or enter new name to create a new falcon_multiqc database")
+            if (database,) in databases or (uri[4],) in databases:     
+                if uri:
+                    check_db_engine = create_engine(f'postgres+psycopg2://{uri[0]}:{uri[1]}@{uri[2]}:{uri[3]}/{uri[4]}')
                 else:
                     check_db_engine = create_engine(f'postgres+psycopg2://{username}:{password}@localhost:5432/{database}')
+                falcon_multiqc_schema = tables_check() # load current falcon_multiqc schema 
                 inspector = inspect(check_db_engine)
-                if not falcon_multiqc_schema == inspector.get_table_names():
+                if len([t for t in falcon_multiqc_schema if t in inspector.get_table_names()]) != len(falcon_multiqc_schema): # checks whether selected db has falcon_multiqc schema
+                    if uri:
+                        click.echo("\n===\nWarning, entered database is not a falcon_multiqc database\n===\n\nExiting falcon_multiqc...")
+                        sys.exit(1)
                     click.echo("\n===\nWarning, selected database is not a falcon_multiqc database, please try again or create a new database\n===\n")
                     continue
+                create_config(username, password, uri, database) # re-create config file with proper connection URL 
                 check_db_engine.dispose()
             else:
                 """Creates a new database"""
                 click.echo("Creating new database...")
-                create_config(username, password, server_address, database) 
+                create_config(username, password, uri, database) 
                 conn.execute("commit") # databases cannot be created inside transactions, this line will close the previous transaction 
-                conn.execute(f"create database {database}") # create an empty database 
+                conn.execute(f"create database {uri[4]}") if uri else conn.execute(f"create database {database}") # create an empty database 
                 from database.crud import create_database
                 create_database() # populate the database with tables 
                 click.echo("Database has been created!")
             break
-        click.echo(f"You are now connected to database {database}!")
+        click.echo(f"You are now connected to database!")
     login_engine.dispose()


### PR DESCRIPTION
For most casses, just use falcon_multiqc connect -> user gets prompted for username/password -> it will check if that's a valid log in -> if yes it will list all avaliable databases under that user -> select one or make a new one -> if selected one is not a falconmq database it will get you to try again -> once selected or new one entered, it will remake the config file

Note: technically the create_tables command is now redundant 

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [ ] `README.md` is updated

