### PR TITLE
Tidying up query code and fixing the click options

### DIFF
--- a/database/process_query.py
+++ b/database/process_query.py
@@ -3,14 +3,16 @@ import csv
 import subprocess 
 import glob
 
-# Creates new csv files given the metric_list (not sure what this is yet) and the abolute path for the user specified directory 
-def create_csv(metric_list, output_dir):
-    with open(metric_list, 'r') as ml:
-        csv_reader = csv.reader(ml)
-        with open(output_dir + '\metrics.csv', 'w') as metrics_csv:
-            csv_writer = csv.writer(metrics_csv, delimiter = ',')
-            for line in csv_reader:
-                csv_writer.writerow(line)
+# Creates new csv with the sqlalchemy query result in the given output directory.
+def create_csv(query_header, query_result, output_dir):
+    with open(output_dir + '\query.csv', 'w') as csv_file:
+        csv_writer = csv.writer(csv_file, delimiter = ',')
+
+        csv_writer.writerow(query_header)
+
+        for row in query_result:
+            csv_writer.writerow(row)
+
 
 # Prints the list of samples (as row) returned from query 
 def print_query(sample_list, output_dir):

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -1,164 +1,131 @@
 import click
 import subprocess
 import sys
+import operator
+
 from database.crud import session_scope
 from database.models import *
 from sqlalchemy import Float
-from sqlalchemy.orm import load_only,Load
+from sqlalchemy.orm import load_only, Load
 from database.process_query import create_new_multiqc, create_csv
 
-# example command:
-# falcon_multiqc query --tool_metric --multiqc -d path
-# User will get prompted due to -tm flag, command will ask for which tool_metrics to filter on
+"""
+This command allows you to query the falcon multiqc database.
 
-# Small query example 
-# verifybamid AVG_DP < 28
-# picard_insertSize MEAN_INSERT_SIZE > 565
-# picard_wgsmetrics PCT_EXC_DUPE <= 0.04
-# Then hit 'enter'
+#TODO: add all argument required and optional and explanations here, similar to save.py.
 
-# large query example:
-# verifybamid AVG_DP < 100
-# picard_insertSize MEAN_INSERT_SIZE > 390
-# picard_wgsmetrics PCT_EXC_DUPE <= 0.021
+Example commands (small):
+falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 28 --multiqc -d path
+falcon_multiqc query --tool_metric picard_insertSize MEAN_INSERT_SIZE '>' 565 --multiqc -d path
+falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.04 --multiqc -d path
 
-# feel free to implment a better user interaction method
-@click.command()
-@click.option('--select', is_flag=True, required=False, help = "Enter what you want to select on, e.g. select for sample_name, batch, etc. (deafult is sample_name)")
-@click.option('--tool_metric', is_flag=True, required=False, help = "Enter tool, metric, operator and number, e.g. verifybamid AVG_DP < 30")
-@click.option('--batch', is_flag=True, required=False, help = "Enter which batches to filter on e.g. AAA, BAA, etc.")
-@click.option('--cohort', is_flag=True, required=False, help = "Enter which cohort to filter on e.g. MGRB, cohort2, etc.")
-@click.option('--multiqc', is_flag=True, required=False, help = "Creates a multiqc report (user must select only for sample_name if so)")
-@click.option('--csv', is_flag=True, required=False, help = "Creates a csv report")
-@click.option("-o", "--output", type=click.STRING, required=True, help="where query result will be saved")
-def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
-    """To use query tool, specify what you would like to select on by using the --select flag (when not used, deafult is sample_name),
-    to specify what to filter on, choose which fields by using either --tool_metric, --batch, or --cohort flags, and then enter the what to filter on """
+Example commands (large):
+falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 100 --multiqc -d path
+falcon_multiqc query --tool_metric picard_insertSize MEAN_INSERT_SIZE '>' 390 --multiqc -d path
+falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.021 --multiqc -d path
 
-    if not select:
-        select = ['sample_name']
+Notes:
+Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
+--tool_metric MUST be the first argument.
+Multiple --tool_metric's can be added as input. 
+
+"""
+
+ops = {
+    '>': operator.gt,
+    '>=': operator.ge,
+    '<': operator.lt,
+    '<=': operator.le,
+    '==': operator.eq,
+    '!=': operator.ne
+}
+
+# TODO: Currently only supports metrics that are float values. Support more.
+def query_metric(session, query, tool, attribute, operator, value):
+    if not query:
+        return (session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool)
+                .join(RawData, Sample.id == RawData.sample_id)
+                .join(Batch, Sample.batch_id == Batch.id)
+                .join(Cohort, Sample.cohort_id == Cohort.id)
+                .filter(RawData.qc_tool == tool, ops[operator](RawData.metrics[attribute].astext.cast(Float), value)))
     else:
-        click.echo("Enter what you want to select on from the database:\nOptions are: sample_name, batch, cohort, tool\nenter 'next' to finish")
-        select = []
-        while True:
-            query = click.prompt("Select")
-            if query == 'next':
-                break
-            select.append(query)
+        return (query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool)
+                            .join(RawData, Sample.id == RawData.sample_id)
+                            .join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id)
+                            .filter(RawData.qc_tool == tool, ops[operator](RawData.metrics[attribute].astext.cast(Float), value))))
+
+@click.command()
+@click.option('--tool_metric', multiple=True, type=(str, str, str, str), required=False, help="Filter by tool, metric, operator and number, e.g. 'verifybamid AVG_DP < 30'.")
+@click.option('--select', multiple=True, default=["sample_name"], required=False, help="What to select on (sample_name, batch, cohort, tool), default is sample_name.")
+@click.option('--batch', multiple=True, required=False, help="Filter by batch name: enter which batches e.g. AAA, BAA, etc.")
+@click.option('--cohort', multiple=True, required=False, help="Filter by cohort id: enter which cohorts e.g. MGRB, cohort2, etc.")
+@click.option('--multiqc', is_flag=True, required=False, help="Create a multiqc report (user must select only for sample_name if so).")
+@click.option('--csv', is_flag=True, required=False, help="Create a csv report.")
+@click.option("-o", "--output", type=click.Path(), required=True, help="Output directory where query result will be saved.")
+def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
+    """Query the falcon qc database by specifying what you would like to select on by using the --select option, and
+    to filter on either --tool_metric, --batch, or --cohort."""
 
     if multiqc:
         if len(select) != 1 and select[0] != 'sample_name':
-            click.echo("If multiqc report is selected, please ensure to select for only sample_name")
+            # TODO: support creating multiqc report with more than one thing selected.
+            # I.e. filter the result before giving to multiqc function.
+            click.echo(
+                "When multiqc report is selected, please ensure to select for only sample_name.")
             sys.exit(1)
 
-    tm_query_list = []
-    if tool_metric:
-        click.echo("Enter any number of queries in the form: <tool metric operator number>\nTo exit, enter nothing\n")
-        while True:
-            query = input("Query (tool/metric/operator/number): ") # note click.prompt is able to capture the 'enter' key, hence using input()
-            if query == '':
-                break
-            if len(query.split()) != 4:
-                click.echo('Incorrect format: Please enter 4 arguments <tool metric operator number> correctly')
-                continue
-            tm_query_list.append(query)
-        
-
-    # for potential future layout idea
-    b_query_list = []
-    if batch:
-        # code
-        pass
-
-    # for potential future layout idea
-    c_query_list = []
-    if cohort:
-        #code
-        pass
-    
-
     click.echo(f"Returning {select} by filtering for:")
-    [click.echo(f'{tm}') for tm in tm_query_list]
-    [click.echo(f'{b}') for b in b_query_list]
-    [click.echo(f'{c}') for c in c_query_list]
+    [click.echo(f'{tm}') for tm in tool_metric]
+    [click.echo(f'{b}') for b in batch]
+    [click.echo(f'{c}') for c in cohort]
 
     ### ================================= FILTER SECTION ==========================================####
 
-    sample_query_set = set() # The former idea behind this set was for it to store only sample_id's 
-                             # However through testing queries against all 4500 samples, it is better to store more basic fields in this set
-                             # Those being sample.id, sample_name, path, batch_name, cohortID, qc_tool
-                             # Having a global set which contains all these means you can perform any potential SELECT action (see the SELECT SECTION)
-    if tm_query_list:
+    # Having a global set which contains all these means you can perform any potential SELECT action (see the SELECT SECTION)
+    sample_query_set = set()
+
+    if tool_metric:
         with session_scope() as session:
-            first_loop = True
-            for query in tm_query_list:
-                query = query.split()
+            tm_query = None
+            for query in tool_metric:
                 tool = query[0]
                 attribute = query[1]
                 operator = query[2]
-                value = query[3] 
-                if operator == '<':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) < value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) < value))
-                    session.expire_on_commit = False
-                if operator == '>':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) > value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) > value))
-                    session.expire_on_commit = False
-                if operator == '==':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) == value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) == value))
-                    session.expire_on_commit = False
-                if operator == '>=':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) >= value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) >= value))
-                    session.expire_on_commit = False
-                if operator == '<=':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) <= value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) <= value))
-                    session.expire_on_commit = False
-                if operator == '!=':
-                    if first_loop:
-                        tm_query = session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) != value)
-                    else:
-                        tm_query = tm_query.union(session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id).filter(RawData.qc_tool == tool, RawData.metrics[attribute].astext.cast(Float) != value))
-                    session.expire_on_commit = False
-                first_loop = False
-            sample_query_set = set(tm_query.all()) # creates set containing every RawData.sample_id filtered accross database which satifies filtering, this acts as a global query set for samples
+                value = query[3]
 
-    # for potential future layout idea
-    if b_query_list:
-        with session_scope() as session: 
-            first_loop = True
-            for query in b_query_list:
-                # b_query = session.query(Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id). ETC
-                pass
-            if sample_query_set: # if the global sample query set is NOT empty, then get intersection with the batch sample query result 
-                sample_query_set = sample_query_set.intersection(sample_query_set, set(b_query.all()))
-            else:
-                sample_query_set = set(b_query.all()) # if the global sample query set IS empty, then populate it with the batch query result etc. 
+                tm_query = query_metric(
+                    session, tm_query, tool, attribute, operator, value)
 
-    # for potential future layout idea
-    if c_query_list:
+            # creates set containing every RawData.sample_id filtered accross database which satifies filtering, this acts as a global query set for samples
+            sample_query_set = set(tm_query.all())
+
+    # TODO: implement filter by cohort: for potential future layout idea.
+    """
+    if cohort:
         with session_scope() as session:
-            first_loop = True
-            for query in c_query_list:
+            for query in cohort:
                 # c_query = session.query(Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id). ETC
                 pass
             if sample_query_set:
-                sample_query_set = sample_query_set.intersection(sample_query_set, set(c_query.all()))
+                sample_query_set = sample_query_set.intersection(
+                    sample_query_set, set(c_query.all()))
             else:
                 sample_query_set = set(c_query.all())
+    """
+    """
+    # TODO: implement filter by batch: for potential future layout idea.
+    if batch:
+        with session_scope() as session:
+            for query in batch:
+                # b_query = session.query(Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id).join(RawData, Sample.id == RawData.sample_id).join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id). ETC
+                pass
+            if sample_query_set:  # if the global sample query set is NOT empty, then get intersection with the batch sample query result
+                sample_query_set = sample_query_set.intersection(
+                    sample_query_set, set(b_query.all()))
+            else:
+                # if the global sample query set IS empty, then populate it with the batch query result etc.
+                sample_query_set = set(b_query.all())
+    """
 
     ### ================================= SELECT SECTION ==========================================####
 
@@ -166,44 +133,51 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
     if 'sample_name' in select:
         with session_scope() as session:
             sample_path_list = []
-            click.echo(f'total query was: {len(sample_query_set)}') 
-            sample_path_list = [(query[1], query[2]) for query in sample_query_set] # used by multiqc function 
+            click.echo(f'total query was: {len(sample_query_set)}')
+            # used by multiqc function
+            sample_path_list = [(query[1], query[2])
+                                for query in sample_query_set]
 
-    #example
+    # example
     if 'qctool' in select:
         with session_scope() as session:
             tool_list = []
-            for row in sample_query_set: # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use 
-                tool = session.query(RawData.qc_tool).filter(Sample.id == row[0]).first()
-                tool_list.append(tool) # list of tuples
+            for row in sample_query_set:  # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use
+                tool = session.query(RawData.qc_tool).filter(
+                    Sample.id == row[0]).first()
+                tool_list.append(tool)  # list of tuples
             tool_set = set(tool_list)
 
-    #example
+    # example
     if 'metric' in select:
         with session_scope() as session:
             metric_list = []
-            for row in sample_query_set: # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use 
-                metric = session.query(RawData.metrics).filter(Sample.id == row[0]).first()
-                metric_list.append(metric) # list of tuples
+            for row in sample_query_set:  # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use
+                metric = session.query(RawData.metrics).filter(
+                    Sample.id == row[0]).first()
+                metric_list.append(metric)  # list of tuples
             metric_set = set(metric_list)
 
-    #example
+    # example
     if 'batch' in select:
         with session_scope() as session:
             batch_list = []
-            for row in sample_query_set: # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use 
-                batch_name = session.query(Batch.batch_name).filter(Sample.id == row[0]).first()
-                batch_list.append(batch_name) # list of tuples
+            for row in sample_query_set:  # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use
+                batch_name = session.query(Batch.batch_name).filter(
+                    Sample.id == row[0]).first()
+                batch_list.append(batch_name)  # list of tuples
             batch_set = set(batch_list)
 
-    #example
+    # example
     if 'sample_batch' in select:
         with session_scope() as session:
             sample_batch_list = []
-            for row in sample_query_set: # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use 
-                sample_name, batch_name = session.query(Sample.sample_name, Batch.batch_name).join(Batch).filter(Sample.id == row[0]).first()
-                sample_batch_list.append((sample_name, batch_name)) # list of tuples
-            sample_batch_set = set(sample_batch_list)            
+            for row in sample_query_set:  # set contains rows consisting of: sample.id, sample_name, batch path, batch_name, cohort.id and tool, so choose what to use
+                sample_name, batch_name = session.query(Sample.sample_name, Batch.batch_name).join(
+                    Batch).filter(Sample.id == row[0]).first()
+                sample_batch_list.append(
+                    (sample_name, batch_name))  # list of tuples
+            sample_batch_set = set(sample_batch_list)
 
     if multiqc:
         click.echo("creating multiqc report...")

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -69,13 +69,10 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
     """Query the falcon qc database by specifying what you would like to select on by using the --select option, and
     to filter on either --tool_metric, --batch, or --cohort."""
 
-    if multiqc:
-        if len(select) != 1 and select[0] != 'sample_name':
-            # TODO: support creating multiqc report with more than one thing selected.
-            # I.e. filter the result before giving to multiqc function.
-            click.echo(
-                "When multiqc report is selected, please ensure to select for only sample_name.")
-            sys.exit(1)
+    if multiqc and "sample_name" not in select:
+        click.echo(
+            "When multiqc report is selected, please ensure to select for sample_name.")
+        sys.exit(1)
 
     click.echo(f"Returning {select} by filtering for:")
     [click.echo(f'{tm}') for tm in tool_metric]

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -86,6 +86,9 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
 
     # Having a global set which contains all these means you can perform any potential SELECT action (see the SELECT SECTION)
     sample_query_set = set()
+    # Keep track of the query header with query.column_descriptions. 
+    # TODO: This should be updated if the query is altered.
+    query_header = []
 
     if tool_metric:
         with session_scope() as session:
@@ -101,6 +104,9 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
 
             # creates set containing every RawData.sample_id filtered accross database which satifies filtering, this acts as a global query set for samples
             sample_query_set = set(tm_query.all())
+
+            for col in tm_query.column_descriptions:
+                query_header.append(col["name"])
 
     # TODO: implement filter by cohort: for potential future layout idea.
     """
@@ -187,5 +193,6 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
         create_new_multiqc(sample_path_list, output)
 
     if csv:
+        # TODO: Change tm_query input if the input changes from the above selecting.
         click.echo("creating csv report...")
-        create_csv(metric_set, output)
+        create_csv(query_header, tm_query, output)

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -22,7 +22,7 @@ falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.04 -
 Example commands (large):
 falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 100 --multiqc -d path
 falcon_multiqc query --tool_metric picard_insertSize MEAN_INSERT_SIZE '>' 390 --multiqc -d path
-falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.021 --multiqc -d path
+falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.5 --multiqc -d path
 
 Notes:
 Special characters must be escaped (wrapped in single quotes) in bash, like '<'.

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -41,6 +41,8 @@ ops = {
 }
 
 # TODO: Currently only supports metrics that are float values. Support more.
+
+
 def query_metric(session, query, tool, attribute, operator, value):
     if not query:
         return (session.query(Sample.id, Sample.sample_name, Batch.path, Batch.batch_name, Cohort.id, RawData.qc_tool)
@@ -54,9 +56,10 @@ def query_metric(session, query, tool, attribute, operator, value):
                             .join(Batch, Sample.batch_id == Batch.id).join(Cohort, Sample.cohort_id == Cohort.id)
                             .filter(RawData.qc_tool == tool, ops[operator](RawData.metrics[attribute].astext.cast(Float), value))))
 
+
 @click.command()
 @click.option('--tool_metric', multiple=True, type=(str, str, str, str), required=False, help="Filter by tool, metric, operator and number, e.g. 'verifybamid AVG_DP < 30'.")
-@click.option('--select', multiple=True, default=["sample_name"], required=False, help="What to select on (sample_name, batch, cohort, tool), default is sample_name.")
+@click.option('--select', multiple=True, default=["sample_name"], type=click.Choice(["sample_name", "batch", "cohort", "tool"], case_sensitive=False), required=False, help="What to select on (sample_name, batch, cohort, tool), default is sample_name.")
 @click.option('--batch', multiple=True, required=False, help="Filter by batch name: enter which batches e.g. AAA, BAA, etc.")
 @click.option('--cohort', multiple=True, required=False, help="Filter by cohort id: enter which cohorts e.g. MGRB, cohort2, etc.")
 @click.option('--multiqc', is_flag=True, required=False, help="Create a multiqc report (user must select only for sample_name if so).")


### PR DESCRIPTION
## PR Description
- You can now use the query command entirely via options.
- Query command code cleanup a tiny bit.
- If an option has multiple=True then you can write it multiple times in the query, e.g. --sample 1 --sample 2.
- The --tool-metric option HAS to be the first option you give the command. Documentation doesn't seem to say this though? So not sure why I found this to be the case, could be a bug.
- When using special characters like = or > in bash command line, you need to escape them by wrapping them in single quotes (e,g, '>').

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [ ] `README.md` is updated

