### PR TITLE
Update query command implementation: do all selecting first, then filtering, in the one query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,28 @@ A tool for parsing multiqc reports into a database and querying from the command
 This command allows you to query the falcon multiqc database.
 
 Select columns to include in output (sample [default], batch, cohort, tool-metric).
-    --select <sample>
+    `--select <sample>`
     (Add multiple selections by using multiple `--select` options)
 
-Add optional filtering with --batch, --cohort, or --tool_metric.
-    --batch <batch name>
-    --cohort <cohort id>
-    --tool-metric <tool name> <metric> <operator> <value>
+Add optional filtering with `--batch`, `--cohort`, or `--tool_metric`.
+    `--batch <batch name>`
+    `--cohort <cohort id>`
+    `--tool-metric <tool name> <metric> <operator> <value>`
     (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
 
 Note (--tool_metric): 
-    You must always specify 4 values. If <operator> is not valid,
-    this is okay and the output will have the <metric> - with no filtering.
+    - You must always specify 4 values. If <operator> is not valid, this is okay and the output will have the <metric> - with no filtering.
+      - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 28 -o path`
+      - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP 0 0 -o path` will select verifybamid AVG_DP in output
+    - `--tool metric` *MUST be the first argument* to falcon_multiqc query.
 
-    MUST be the first argument to falcon_multiqc query.
+    - Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
 
-    Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
+Specify output directory with `--output or -o`. 
+
+Specify output type with either `--csv` or `--multiqc`.
+- Default output is stdout.
+
 
 ## Dev instructions
 1. `git clone https://github.com/lwratten/project-falcon.git`

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A tool for parsing multiqc reports into a database and querying from the command
 ## User instructions
 - The below dev instructions + `falcon_multiqc` command.
 - Use `falcon_multiqc --help` to see all available commands
-### Save commands
+
+### Save command
 - Use `falcon_multiqc save --help` to see how to use save.
 - E.g. `falcon_multiqc save --directory multiqc/output/path --sample_metadata meta_data_file`
 - `--sample_metadata` is a required argument - A csv with the header: `Sample,Name,Cohort,Name,Batch,Name,Flowcell.Lane,Library ID,Platform,Centre of Sequencing,Reference Genome,Type,Description`
@@ -13,6 +14,26 @@ A tool for parsing multiqc reports into a database and querying from the command
   - `--cohort_description` {string} -- Set this if the input is 1 cohort. Will apply this description to all new cohorts.
   - `--batch_metadata` {file} -- A csv with header `Batch Name,Description`. Set this if the input is multiple batches.
 
+### Query command
+This command allows you to query the falcon multiqc database.
+
+Select columns to include in output (sample [default], batch, cohort, tool-metric).
+    --select <sample>
+    (Add multiple selections by using multiple `--select` options)
+
+Add optional filtering with --batch, --cohort, or --tool_metric.
+    --batch <batch name>
+    --cohort <cohort id>
+    --tool-metric <tool name> <metric> <operator> <value>
+    (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
+
+Note (--tool_metric): 
+    You must always specify 4 values. If <operator> is not valid,
+    this is okay and the output will have the <metric> - with no filtering.
+
+    MUST be the first argument to falcon_multiqc query.
+
+    Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
 
 ## Dev instructions
 1. `git clone https://github.com/lwratten/project-falcon.git`

--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ This command allows you to query the falcon multiqc database.
 - Select columns to include in output (sample [default], batch, cohort, tool-metric).
     `--select <sample>`
     (Add multiple selections by using multiple `--select` options)
-- Add optional filtering with `--batch`, `--cohort`, or `--tool_metric`.
+- Add optional filtering with `--batch`, `--cohort`, or `--tool-metric`.
     - `--batch <batch name>`
     - `--cohort <cohort id>`
     - `--tool-metric <tool name> <metric> <operator> <value>`
     (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
-- Note (--tool_metric): 
+- Note (--tool-metric): 
     - You must always specify 4 values. If <operator> is not valid, this is okay and the output will have the <metric> - with no filtering.
       
-      - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 28 -o path`
+      - e.g. `falcon_multiqc query --tool-metric verifybamid AVG_DP '<' 28 -o path`
 
-      - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP 0 0 -o path` will select verifybamid AVG_DP in output
+      - e.g. `falcon_multiqc query --tool-metric verifybamid AVG_DP 0 0 -o path` will select verifybamid AVG_DP in output
     
 
     - `--tool metric` *MUST be the first argument* to falcon_multiqc query.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ This command allows you to query the falcon multiqc database.
 - Select columns to include in output (sample [default], batch, cohort, tool-metric).
     `--select <sample>`
     (Add multiple selections by using multiple `--select` options)
-
 - Add optional filtering with `--batch`, `--cohort`, or `--tool_metric`.
     - `--batch <batch name>`
     - `--cohort <cohort id>`
     - `--tool-metric <tool name> <metric> <operator> <value>`
     (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
-
 - Note (--tool_metric): 
     - You must always specify 4 values. If <operator> is not valid, this is okay and the output will have the <metric> - with no filtering.
       
@@ -40,7 +38,6 @@ This command allows you to query the falcon multiqc database.
     - Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
 
 - Specify output directory with `--output or -o`. 
-
 - Specify output type with either `--csv` or `--multiqc`.
    - Default output is stdout.
 

--- a/README.md
+++ b/README.md
@@ -17,28 +17,32 @@ A tool for parsing multiqc reports into a database and querying from the command
 ### Query command
 This command allows you to query the falcon multiqc database.
 
-Select columns to include in output (sample [default], batch, cohort, tool-metric).
+- Select columns to include in output (sample [default], batch, cohort, tool-metric).
     `--select <sample>`
     (Add multiple selections by using multiple `--select` options)
 
-Add optional filtering with `--batch`, `--cohort`, or `--tool_metric`.
-    `--batch <batch name>`
-    `--cohort <cohort id>`
-    `--tool-metric <tool name> <metric> <operator> <value>`
+- Add optional filtering with `--batch`, `--cohort`, or `--tool_metric`.
+    - `--batch <batch name>`
+    - `--cohort <cohort id>`
+    - `--tool-metric <tool name> <metric> <operator> <value>`
     (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
 
-Note (--tool_metric): 
+- Note (--tool_metric): 
     - You must always specify 4 values. If <operator> is not valid, this is okay and the output will have the <metric> - with no filtering.
+      
       - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 28 -o path`
+
       - e.g. `falcon_multiqc query --tool_metric verifybamid AVG_DP 0 0 -o path` will select verifybamid AVG_DP in output
+    
+
     - `--tool metric` *MUST be the first argument* to falcon_multiqc query.
 
     - Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
 
-Specify output directory with `--output or -o`. 
+- Specify output directory with `--output or -o`. 
 
-Specify output type with either `--csv` or `--multiqc`.
-- Default output is stdout.
+- Specify output type with either `--csv` or `--multiqc`.
+   - Default output is stdout.
 
 
 ## Dev instructions

--- a/database/process_query.py
+++ b/database/process_query.py
@@ -13,11 +13,6 @@ def create_csv(query_header, query_result, output_dir):
         for row in query_result:
             csv_writer.writerow(row)
 
-
-# Prints the list of samples (as row) returned from query 
-def print_query(sample_list, output_dir):
-    [print(sample_list[i]) for i in sample_list]
-
 # Requires list containing tuples in the form (sample_name, path), and requires user specified output directory path 
 # Function will find and save all files matching sample_name and return file
 def create_new_multiqc(path_sample_list, output_dir):
@@ -35,7 +30,6 @@ def create_new_multiqc(path_sample_list, output_dir):
         for path in map_path_sample.keys(): # for each batch folder path
             os.chdir(path) # change directory to path
             for sample_name in map_path_sample[path]: # go through each sample_name in given batch folder path
-                print(f'sample id is: {sample_name}')
                 for file_name in glob.glob(sample_name + '*'): # find every file assoicated with sample_name
                     sample_filenames.write(path + '/' + file_name + '\n') # write into file
                     #TODO this is the part that takes ages because it's searching sample_name in a folder containing 96,000 files. We need to break up the folder into the 10 batch folders

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -109,11 +109,6 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
             "When multiqc report is selected, please ensure to select for sample.")
         sys.exit(1)
 
-    click.echo(f"Returning {select} by filtering for:")
-    [click.echo(f'{tm}') for tm in tool_metric]
-    [click.echo(f'{b}') for b in batch]
-    [click.echo(f'{c}') for c in cohort]
-
     # Keep track of the query header with query.column_descriptions. 
     # TODO: This should be updated if the query is altered.
     query_header = []
@@ -159,3 +154,9 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
     if csv:
         click.echo("creating csv report...")
         create_csv(query_header, falcon_query, output)
+
+    if not multiqc and not csv:
+        # Print result
+        click.echo(query_header)
+        for row in falcon_query:
+            click.echo(row)

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -12,23 +12,23 @@ from database.process_query import create_new_multiqc, create_csv
 """
 This command allows you to query the falcon multiqc database.
 
-#TODO: add all argument required and optional and explanations here, similar to save.py.
+Select columns to include in output (sample [default], batch, cohort, tool-metric).
+    --select <sample>
+    (Add multiple selections by using multiple `--select` options)
 
-Example commands (small):
-falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 28 --multiqc -d path
-falcon_multiqc query --tool_metric picard_insertSize MEAN_INSERT_SIZE '>' 565 --multiqc -d path
-falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.04 --multiqc -d path
+Add optional filtering with --batch, --cohort, or --tool_metric.
+    --batch <batch name>
+    --cohort <cohort id>
+    --tool-metric <tool name> <metric> <operator> <value>
+    (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
 
-Example commands (large):
-falcon_multiqc query --tool_metric verifybamid AVG_DP '<' 100 --multiqc -d path
-falcon_multiqc query --tool_metric picard_insertSize MEAN_INSERT_SIZE '>' 390 --multiqc -d path
-falcon_multiqc query --tool_metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.5 --multiqc -d path
+Note (--tool_metric): 
+    You must always specify 4 values. If <operator> is not valid,
+    this is okay and the output will have the <metric> - with no filtering.
 
-Notes:
-Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
---tool_metric MUST be the first argument.
-Multiple --tool_metric's can be added as input. 
+    MUST be the first argument to falcon_multiqc query.
 
+    Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
 """
 
 ops = {
@@ -85,7 +85,7 @@ def query_select(session, columns, tool_metric_filters, multiqc):
 
 # TODO: Currently only supports metrics that are float values. Support more.
 # Returns a sqlalchemy query that queries the database with a filter
-# created from the given tool, attribute, operator and value. 
+# with the given tool, attribute, operator and value.
 def query_metric(session, query, tool, attribute, operator, value):
     if operator not in ops:
         # If user has not given a valid operator, do not filter on metric, just tool.

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -85,7 +85,7 @@ def query_select(session, columns, tool_metric_filters, multiqc):
 # TODO: Currently only supports metrics that are float values. Support more.
 # Returns a sqlalchemy query that queries the database with a filter
 # with the given tool, attribute, operator and value.
-def query_metric(session, query, tool, attribute, operator, value):
+def filter_metric(session, query, tool, attribute, operator, value):
     # TODO: change this to support mulitple filters.
     # Need to support multiple filters (OR) and multiple filters (AND)
     if operator not in ops:
@@ -94,12 +94,12 @@ def query_metric(session, query, tool, attribute, operator, value):
     return query.filter(RawData.qc_tool == tool, ops[operator](RawData.metrics[attribute].astext.cast(Float), value))
 
 @click.command()
-@click.option('-s, --select', multiple=True, default=["sample"], type=click.Choice(["sample", "batch", "cohort", "tool-metric"], case_sensitive=False), required=False, help="What to select on (sample_name, batch, cohort, tool), default is sample_name.")
-@click.option('--tm, --tool-metric', multiple=True, type=(str, str, str, str), required=False, help="Filter by tool, metric, operator and number, e.g. 'verifybamid AVG_DP < 30'.")
-@click.option('-b, --batch', multiple=True, required=False, help="Filter by batch name: enter which batches e.g. AAA, BAA, etc.")
-@click.option('-c, --cohort', multiple=True, required=False, help="Filter by cohort id: enter which cohorts e.g. MGRB, cohort2, etc.")
-@click.option('--multiqc', is_flag=True, required=False, help="Create a multiqc report (user must select only for sample_name if so).")
-@click.option('--csv', is_flag=True, required=False, help="Create a csv report.")
+@click.option("-s", "--select", multiple=True, default=["sample"], type=click.Choice(["sample", "batch", "cohort", "tool-metric"], case_sensitive=False), required=False, help="What to select on (sample_name, batch, cohort, tool), default is sample_name.")
+@click.option("-tm", "--tool-metric", multiple=True, type=(str, str, str, str), required=False, help="Filter by tool, metric, operator and number, e.g. 'verifybamid AVG_DP < 30'.")
+@click.option("-b", "--batch", multiple=True, required=False, help="Filter by batch name: enter which batches e.g. AAA, BAA, etc.")
+@click.option("-c", "--cohort", multiple=True, required=False, help="Filter by cohort id: enter which cohorts e.g. MGRB, cohort2, etc.")
+@click.option("--multiqc", is_flag=True, required=False, help="Create a multiqc report (user must select only for sample_name if so).")
+@click.option("--csv", is_flag=True, required=False, help="Create a csv report.")
 @click.option("-o", "--output", type=click.Path(), required=True, help="Output directory where query result will be saved.")
 def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
     """Query the falcon qc database by specifying what you would like to select on by using the --select option, and
@@ -117,8 +117,9 @@ def cli(select, tool_metric, batch, cohort, multiqc, csv, output):
     falcon_query = None
 
     ### ================================= SELECT  ==========================================####
-    with session_scope() as session:
-        falcon_query = query_select(session, select, tool_metric, multiqc)
+    # TODO: fix metrics.
+    #with session_scope() as session:
+    #    falcon_query = query_select(session, select, tool_metric, multiqc)
 
     ### ================================= FILTER  ==========================================####
     ## 1. Tool - Metric


### PR DESCRIPTION
- Changing implementation of query. 

  - Since we know all the user input from the start, we can first do our selecting (build the query select + joins). Then add any filtering needed. Then finally, execute the query - all in the one sqlalchemy query (similar to constructing an actual SQL query).


- Updated documentation

- Now csv/stdout output has the columns you selected in it.

- Also added support for selecting the tool-metric. So the tool name, and metric will be in the output as a column.

 - You can also simply select on the tool-metric WITHOUT filtering, like so `--tool-metric verifybamid AVG_DP 0 0`. This way is used when it detects the operator is invalid, so you could write anything in place of the 0s. But click requires 4 arguments for tool-metric, so something has to be in operator/value spot.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [x] `README.md` is updated

