### PR TITLE
More flexible querying

### DIFF
--- a/database/process_query.py
+++ b/database/process_query.py
@@ -12,6 +12,7 @@ def create_csv(query_header, query_result, output_dir):
 
         for row in query_result:
             csv_writer.writerow(row)
+    print("csv report created!")
 
 # Requires list containing tuples in the form (sample_name, path), and requires user specified output directory path 
 # Function will find and save all files matching sample_name and return file
@@ -21,7 +22,7 @@ def create_new_multiqc(path_sample_list, output_dir):
     if type(path_sample_list) != type([]) and type(path_sample_list[0]) != type(()) and len(path_sample_list[0]) != 2:
         raise Exception("Invalid input: this function only accepts lists containing tuples of the form (sample_name, path)")
 
-    if len(path_sample_list == 0):
+    if len(path_sample_list) == 0:
         raise Exception("No results from query")
 
     for sample_name, path in path_sample_list:

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -288,8 +288,7 @@ def cli(
     ### ================================= SELECT  ==========================================####
     # item in index 0 of select don't need to be added to join['joins']
     # both select and filter options influence whether certain tables need to be joined, the following handles this
-
-    select = list(select) # needed for join section
+    
     join = {'joins': set(), 'joined': set()} # keeping track of what needs to be joined, and what has been joined
     if multiqc and "sample" not in select:
         select.insert(0, 'sample')

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -326,7 +326,7 @@ def cli(
         falcon_query = falcon_query.filter(Sample.platform.in_(platform))
 
     if centre:
-        falcon_query = falcon_query.filter(Sample.platform.in_(centre))
+        falcon_query = falcon_query.filter(Sample.centre.in_(centre))
 
     if reference:
         falcon_query = falcon_query.filter(Sample.reference_genome.in_(reference))

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -68,7 +68,7 @@ def query_select(session, columns, join, tool_metric_filters, multiqc):
         select_cols.append(Batch.path)
 
     query = Query(select_cols, session=session)
-    join['joined'].add(columns[0]) # the first select of a given query doesn't need to be explicitly joined
+    join['joined'].add(columns[0]) # The first item in select query doesn't need to be explicitly joined
 
     ### ================================= JOIN  ==========================================####
     # Add the table joins needed for the given column selection or filtering.
@@ -83,7 +83,7 @@ def query_select(session, columns, join, tool_metric_filters, multiqc):
             query = query.join(Sample, Sample.cohort_id == Cohort.id)
         join['joined'].add('sample')
 
-    # for multiqc we need Batch for batch.path.
+    # For multiqc we need Batch for batch.path.
     if (multiqc or 'batch' in join['joins']) and 'batch' not in join['joined']:
         if 'tool-metric' in join['joined'] and 'sample' not in join['joined']:
             query = query.join(Sample, Sample.id == RawData.sample_id)
@@ -286,11 +286,10 @@ def cli(
     falcon_query = None
 
     ### ================================= SELECT  ==========================================####
-    # item in index 0 of select don't need to be added to join['joins']
-    # both select and filter options influence whether certain tables need to be joined, the following handles this
+    # Both select and filter options influence whether certain tables need to be joined, the following handles this.
 
-    select = list(select) # needed for join section
-    join = {'joins': set(), 'joined': set()} # keeping track of what needs to be joined, and what has been joined
+    select = list(select) 
+    join = {'joins': set(), 'joined': set()} # Keeping track of what needs to be joined, and what has been joined.
     if multiqc and "sample" not in select:
         select.insert(0, 'sample')
     if sample_description or flowcell_lane or library_id or platform or centre or reference or type or 'sample' in select: 
@@ -368,7 +367,7 @@ def cli(
         create_csv(query_header, falcon_query, output)
 
     if not multiqc and not csv:
-        # Print result
+        # Print result.
         click.echo(query_header)
         for row in falcon_query:
             click.echo(row)

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -5,34 +5,26 @@ import operator
 
 from database.crud import session_scope
 from database.models import Base, Sample, Batch, Cohort, RawData
-from sqlalchemy import Float, or_, and_, func
+from sqlalchemy import Float, or_, and_, func, distinct
 from sqlalchemy.orm import load_only, Load, Query
 from database.process_query import create_new_multiqc, create_csv
 
 """
 This command allows you to query the falcon multiqc database.
-
 Select columns to include in output (sample [default], batch, cohort, tool-metric).
     --select <sample>
     - Add multiple selections by using multiple `--select` options)
     - The order of these --select/s are the column order of output.
-
 Add optional filtering with --batch, --cohort, or --tool_metric.
     --batch <batch name> (behaves like OR when multiple)
     --cohort <cohort id> (behaves like OR when multiple)
     --tool-metric <tool name> <metric> <operator> <value> (behaves like AND when multiple)
     (Add multiple filters by using multiple `--batch` / `--cohort` / `--tool-metric' options)
-
 Note (--tool_metric): 
     You must always specify 4 values. 
-
     If any <operator> is not valid, output will have the <metric>s - with no filtering. So,
     to simply output all samples with a metric, use <tool> <metric> 0 0.
-
-    MUST be the first argument to falcon_multiqc query.
-
     Special characters must be escaped (wrapped in single quotes) in bash, like '<'.
-
 See example equivalent SQL of what this command does at the end of this file.
 """
 
@@ -48,8 +40,18 @@ ops = {
 # Returns a sqlaclhemy query, selecting on the given columns.
 # Columns supported: 'sample' (sample_name), 'batch', 'cohort', 'tool'.
 # tool_metric is used to determine what metric to select on, if filtered.
-def query_select(session, columns, tool_metric_filters, multiqc):
+def query_select(session, columns, join, tool_metric_filters, multiqc):
     # Add the Sqlalchemy class columns needed for the given column selection.
+
+    # this section allows for the cases where user selects/filters for tm 
+    # with/without batch/cohort without selecting/filtering for sample
+    if 'sample' not in join['joins'] and 'tool-metric' in join['joins']:
+        if columns[0] == 'tool-metric': # joins work better if this is not first
+            columns.remove('tool-metric')
+            columns.append('tool-metric')
+        if 'batch' in join['joins'] or 'cohort' in join['joins']:
+            join['joins'].add('sample')
+
     select_cols = []
 
     # Order of the column output is the order of user's --select input.
@@ -68,50 +70,74 @@ def query_select(session, columns, tool_metric_filters, multiqc):
                     c = func.max(RawData.metrics[tm[1]].astext).label(tm[1])
                     c.quote = True
                     select_cols.append(c)
+            else:
+                select_cols.append(RawData.qc_tool)
     if multiqc:
         # Need to add batch paths.
         select_cols.append(Batch.path)
 
     query = Query(select_cols, session=session)
+    join['joined'].add(columns[0]) # the first select of a given query doesn't need to be explicitly joined
 
-    # Add the table joins needed for the given column selection.
-    if 'sample' in columns or 'batch' in columns:
-        # We need Batch for batch.path for both sample and batch.
-        query = query.join(Batch, Sample.batch_id == Batch.id)
-    
-    if 'tool-metric' in columns: 
-        query = query.join(RawData, Sample.id == RawData.sample_id)
+    ### ================================= JOIN  ==========================================####
+    # Add the table joins needed for the given column selection or filtering.
 
-    if 'cohort' in columns:
-        query = query.join(Cohort, Sample.cohort_id == Cohort.id)
+    if 'sample' in join['joins'] and 'sample' not in join['joined']:
+        if 'batch' in join['joined']:
+            query = query.join(Sample, Batch.id == Sample.batch_id)
+        elif 'cohort' in join['joined']:
+            query = query.join(Sample, Sample.cohort_id == Cohort.id)
+        join['joined'].add('sample')
+
+    # for multiqc we need Batch for batch.path.
+    if (multiqc or 'batch' in join['joins']) and 'batch' not in join['joined']:
+        if 'sample' in join['joined']:
+            query = query.join(Batch, Batch.id == Sample.batch_id)
+        elif 'cohort' in join['joined']:
+            query = query.join(Batch, Batch.cohort_id == Cohort.id)
+        join['joined'].add('batch')
+
+    if 'cohort' in join['joins'] and 'cohort' not in join['joined']:
+        if 'sample' in join['joined']:
+            query = query.join(Cohort, Sample.cohort_id == Cohort.id)
+        elif 'batch' in join['joined']:
+            query = query.join(Cohort, Batch.cohort_id == Cohort.id)
+        join['joined'].add('cohort')
+
+    if 'tool-metric' in join['joins'] and 'tool-metric' not in join['joined']:
+        query = query.join(RawData, RawData.sample_id == Sample.id)
+        join['joined'].add('tool-metric')
 
     return query
 
 # TODO: Currently only supports metrics that are float values. Support more.
 # Returns a sqlalchemy query that queries the database with a filter
 # with the given tool, attribute, operator and value.
-def query_metric(query, select, tool_metric):
+def query_metric(query, join, tool_metric):
     group_by_columns = []
-
-    if 'sample' in select:
-        group_by_columns.append(Sample.id)
-
-    if 'batch' in select:
+    
+    if 'batch' in join['joined']:
         group_by_columns.append(Batch.id)
     
-    if 'cohort' in select:
+    if 'cohort' in join['joined']:
         group_by_columns.append(Cohort.id)
+
+    if 'sample' in join['joined']:
+        group_by_columns.append(Sample.id)
+    
+    if 'tool-metric' in join['joined']:
+        group_by_columns.append(RawData.sample_id)
 
     # Check operator validity.
     # If ANY operator is invalid - we detect user wants to filter based on metric (WITHOUT a conditional value).
     for tm in tool_metric:
         if tm[2] not in ops:
             return (query.filter(or_(RawData.qc_tool == tool for tool, attribute, operator, value in tool_metric))
-                .group_by(*group_by_columns).having(func.count(RawData.qc_tool) == len(tool_metric)))
+            .group_by(*group_by_columns).having(func.count(RawData.qc_tool) == len(tool_metric)))
 
     return (query.filter(or_(and_(RawData.qc_tool == tool, ops[operator](RawData.metrics[attribute].astext.cast(Float), value)) 
-                for tool, attribute, operator, value in tool_metric))
-            .group_by(*group_by_columns).having(func.count(RawData.qc_tool) == len(tool_metric)))
+            for tool, attribute, operator, value in tool_metric)).group_by(*group_by_columns).
+            having(func.count(distinct(RawData.qc_tool)) == len(tool_metric)))
 
 @click.command()
 @click.option(
@@ -212,7 +238,7 @@ def query_metric(query, select, tool_metric):
     "--multiqc",
     is_flag=True,
     required=False,
-    help="Create a multiqc report (user must select only for sample_name if so).")
+    help="Create a multiqc report.")
 
 @click.option(
     "--csv", 
@@ -224,7 +250,7 @@ def query_metric(query, select, tool_metric):
     "-o",
     "--output",
     type=click.Path(),
-    required=True,
+    required=False,
     help="Output directory where query result will be saved.")    
 
 def cli(
@@ -248,24 +274,42 @@ def cli(
     """Query the falcon qc database by specifying what you would like to select on by using the --select option, and
     what to filter on (--tool_metric, --batch, or --cohort)."""
 
-    if multiqc and "sample" not in select:
-        click.echo(
-            "When multiqc report is selected, please ensure to select for sample.")
+    if multiqc or csv and not output:
+        click.echo("When using multiqc or csv option, please specify a directory to save in using the -o option")
         sys.exit(1)
 
     # Sqlaclehmy query that will be constructed based on this command's options.
     falcon_query = None
 
     ### ================================= SELECT  ==========================================####
+    # item in index 0 of select don't need to be added to join['joins']
+    # both select and filter options influence whether certain tables need to be joined, the following handles this
+
+    select = list(select) # needed for manipulating ordering 
+    join = {'joins': set(), 'joined': set()} # keeping track of what needs to be joined, and what has been joined
+    if multiqc and "sample" not in select:
+        select.insert(0, 'sample')
+    if sample_description or flowcell_lane or library_id or platform or centre or reference or type or 'sample' in select[1:]: 
+        join['joins'].add('sample')
+    if cohort or cohort_description or 'cohort' in select[1:]:
+        join['joins'].add('cohort')
+    if batch or batch_description or 'batch' in select[1:]:
+        join['joins'].add('batch')
+    if tool_metric or 'tool-metric' in select[1:]:
+        join['joins'].add('tool-metric')
+    if 'sample' in select and select[0] != 'sample':
+        select.remove('sample')
+        select.insert(0, 'sample') # keeping sample first helps with joining Rawdata table
+    [join['joins'].add(s) for s in select]
 
     with session_scope() as session:
-        falcon_query = query_select(session, select, tool_metric, multiqc)
+        falcon_query = query_select(session, select, join, tool_metric, multiqc)
 
     ### ================================= FILTER  ==========================================####
 
     ## 1. Sample
     if tool_metric:
-        falcon_query = query_metric(falcon_query, select, tool_metric)
+        falcon_query = query_metric(falcon_query, join, tool_metric)
 
     if sample_description:
         conditions = [Sample.description.contains(d, autoescape=True) for d in sample_description]
@@ -334,16 +378,13 @@ Query:
     -tm verifybamid AVG_DP '<' 28 \
     -tm picard_insertSize MEAN_INSERT_SIZE '>' 490 \
     -o output
-
 SQL:
     SELECT sample.id AS sample_id, 
     sample.sample_name AS sample_sample_name,
     max(raw_data.metrics ->> 'AVG_DP') AS AVG_DP, -- results in AVG_DP as its own column
     max(raw_data.metrics ->> 'MEAN_INSERT_SIZE') AS MEAN_INSERT_SIZE -- results in MEAN_INSERT_SIZE as its own column
     FROM sample JOIN batch ON sample.batch_id = batch.id JOIN raw_data ON sample.id = raw_data.sample_id 
-
     WHERE (raw_data.qc_tool='verifybamid' AND CAST((raw_data.metrics ->> 'AVG_DP') AS FLOAT) < 28) 
     OR (raw_data.qc_tool='picard_insertSize' AND CAST((raw_data.metrics ->> 'MEAN_INSERT_SIZE') AS FLOAT) > 490) 
-
     GROUP BY sample.id HAVING count(distinct raw_data.qc_tool) = 2 -- prevents duplicate sample.id rows
 """

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -289,21 +289,18 @@ def cli(
     # item in index 0 of select don't need to be added to join['joins']
     # both select and filter options influence whether certain tables need to be joined, the following handles this
 
-    select = list(select) # needed for manipulating ordering 
+    select = list(select) # needed for join section
     join = {'joins': set(), 'joined': set()} # keeping track of what needs to be joined, and what has been joined
     if multiqc and "sample" not in select:
         select.insert(0, 'sample')
-    if sample_description or flowcell_lane or library_id or platform or centre or reference or type or 'sample' in select[1:]: 
+    if sample_description or flowcell_lane or library_id or platform or centre or reference or type or 'sample' in select: 
         join['joins'].add('sample')
-    if cohort or cohort_description or 'cohort' in select[1:]:
+    if cohort or cohort_description or 'cohort' in select:
         join['joins'].add('cohort')
-    if batch or batch_description or 'batch' in select[1:]:
+    if batch or batch_description or 'batch' in select:
         join['joins'].add('batch')
-    if tool_metric or 'tool-metric' in select[1:]:
+    if tool_metric or 'tool-metric' in select:
         join['joins'].add('tool-metric')
-    if 'sample' in select and select[0] != 'sample':
-        select.remove('sample')
-        select.insert(0, 'sample') # keeping sample first helps with joining Rawdata table
     [join['joins'].add(s) for s in select]
 
     with session_scope() as session:

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -71,14 +71,13 @@ def query_select(session, columns, join, tool_metric_filters, multiqc):
     join['joined'].add(columns[0]) # The first item in select query doesn't need to be explicitly joined
 
     ### ================================= JOIN  ==========================================####
-    # Add the table joins needed for the given column selection or filtering.
-    # TODO condense this with a function potentially 
+    # Add the table joins needed for the given column selection or filtering.   
 
     if 'sample' in join['joins'] and 'sample' not in join['joined']:
         if 'tool-metric' in join['joined']:
             query = query.join(Sample, Sample.id == RawData.sample_id)
         elif 'batch' in join['joined']:
-            query = query.join(Sample, Batch.id == Sample.batch_id)
+            query = query.join(Sample, Sample.batch_id == Batch.id)
         elif 'cohort' in join['joined']:
             query = query.join(Sample, Sample.cohort_id == Cohort.id)
         join['joined'].add('sample')
@@ -99,14 +98,14 @@ def query_select(session, columns, join, tool_metric_filters, multiqc):
             query = query.join(Sample, Sample.id == RawData.sample_id)
             join['joined'].add('sample')
         if 'sample' in join['joined']:
-            query = query.join(Cohort, Sample.cohort_id == Cohort.id)
+            query = query.join(Cohort, Cohort.id == Sample.cohort_id)
         elif 'batch' in join['joined']:
-            query = query.join(Cohort, Batch.cohort_id == Cohort.id)
+            query = query.join(Cohort, Cohort.id == Batch.cohort_id)
         join['joined'].add('cohort')
 
     if 'tool-metric' in join['joins'] and 'tool-metric' not in join['joined']:
         if 'batch' in join['joined'] and 'sample' not in join['joined']:
-            query = query.join(Sample, Batch.id == Sample.batch_id)
+            query = query.join(Sample, Sample.batch_id == Batch.id)
         elif 'cohort' in join['joined'] and 'sample' not in join['joined']:
             query = query.join(Sample, Sample.cohort_id == Cohort.id)
         query = query.join(RawData, RawData.sample_id == Sample.id)

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -288,7 +288,8 @@ def cli(
     ### ================================= SELECT  ==========================================####
     # item in index 0 of select don't need to be added to join['joins']
     # both select and filter options influence whether certain tables need to be joined, the following handles this
-    
+
+    select = list(select) # needed for join section
     join = {'joins': set(), 'joined': set()} # keeping track of what needs to be joined, and what has been joined
     if multiqc and "sample" not in select:
         select.insert(0, 'sample')

--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -274,7 +274,7 @@ def cli(
     """Query the falcon qc database by specifying what you would like to select on by using the --select option, and
     what to filter on (--tool_metric, --batch, or --cohort)."""
 
-    if multiqc or csv and not output:
+    if (multiqc or csv) and not output:
         click.echo("When using multiqc or csv option, please specify a directory to save in using the -o option")
         sys.exit(1)
 


### PR DESCRIPTION
Now the user doesn't have to worry about what joins needed for certain filters or selects combinations. They can put any combination of select and/or filter and it should produce a meaningful result.

This also extends to --multiqc or --csv flags, the user doesn't have to worry about selects, they can just add any combination of filters they want

-o output option is no longer required, as this interferes with stdout option. Instead, the user is prompted if -o is missing when using -multiqc/csv flag

Please try queries which may break it and verify them with pgadmin.




## PR Description
insert description here

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [ ] `README.md` is updated

