### PR TITLE
Tool-metric exception and oversight fix

### DIFF
--- a/falcon_multiqc/commands/query.py
+++ b/falcon_multiqc/commands/query.py
@@ -416,6 +416,16 @@ def cli(
     ### ============================== RESULT / OUTPUT =======================================####
     if len(falcon_query.all()) == 0:
         for tm in tool_metric:
+            # Check whether tool is valid.
+            if session.query(RawData.id).filter(RawData.qc_tool == tm[0]).first() is None:
+                raise Exception(f"The tool {tm[0]} is not present in the database, please check its validity.")
+            
+            metrics = session.query(RawData.metrics).filter(RawData.qc_tool == tm[0]).first()
+            if tm[1] not in metrics[0]:
+                raise Exception(f"The metric {tm[1]} is not present in the metrics of tool {tm[0]}, please check its validity.")
+
+        raise Exception("No results from query")
+        for tm in tool_metric:
             # Check whether tool/metric are correctly spelled.
             try:
                 if session.query(RawData).filter(RawData.qc_tool == tm[0]).scalar() is None:


### PR DESCRIPTION
If invalid tool or metric spelling occurs, exception will be raised

Fixes issue of query not being able to correctly filter when multiple -tm of the same tool present, e.g.

`falcon_multiqc query --select sample -tm picard_gcbias READS_USED '==' ALL --pretty -tm picard_gcbias AT_DROPOUT '>' 2`

`falcon_multiqc query --select sample --select tool-metric --tool-metric picard_insertSize MEAN_INSERT_SIZE '>' 420 --tool-metric verifybamid AVG_DP '<' 30 --tool-metric verifybamid '#READS' '<' 2469490 --tool-metric picard_wgsmetrics PCT_EXC_DUPE '<=' 0.0921`

## PR Description
insert description here

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the CI test suite passes (coming soon...).
 - [ ] Make sure your code lints (coming soon...).
 - [ ] `CHANGELOG.md` is updated (if >=v1.0.0)
 - [ ] `README.md` is updated

